### PR TITLE
fix: replace SSE-C with SSE-KMS for S3 backend encryption [JAINFRA-234]

### DIFF
--- a/docs/migrate-s3-sse-c-to-sse-kms.md
+++ b/docs/migrate-s3-sse-c-to-sse-kms.md
@@ -1,0 +1,143 @@
+# Migration Procedure: S3 SSE-C to SSE-KMS
+
+## Background
+
+The vault-init S3 backend previously used SSE-C (Server-Side Encryption with Customer-Provided Keys), where the AES-256 encryption key was passed as the `AWS_ENCRYPTION_KEY` environment variable. This exposed the key in the pod spec, process environment, and any observability tooling that captures env vars.
+
+The new implementation uses SSE-KMS (Server-Side Encryption with AWS KMS), where the data encryption key never leaves AWS KMS. The pod only needs the KMS key ARN/ID (`AWS_KMS_KEY_ID`) and IAM permissions to call `kms:Encrypt`/`kms:Decrypt`/`kms:GenerateDataKey` on that key.
+
+## Prerequisites
+
+- AWS KMS key (CMK) created in the same region as the S3 bucket
+- IAM role used by vault-init must have the following KMS permissions on the CMK:
+  - `kms:Encrypt`
+  - `kms:Decrypt`
+  - `kms:GenerateDataKey`
+- IAM role must retain `s3:GetObject` and `s3:PutObject` on the vault bucket
+
+## Migration Steps
+
+### 1. Identify Existing Encrypted Objects
+
+```bash
+# List the vault objects in the S3 bucket
+aws s3 ls s3://<BUCKET_NAME>/<BUCKET_PATH>/vault/
+```
+
+Expected objects:
+- `vault/unseal-keys.json`
+- `vault/root-token`
+
+### 2. Download Objects Using the Old SSE-C Key
+
+```bash
+# Download unseal-keys.json with SSE-C
+aws s3api get-object \
+  --bucket <BUCKET_NAME> \
+  --key <BUCKET_PATH>/vault/unseal-keys.json \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key <BASE64_ENCODED_ENCRYPTION_KEY> \
+  unseal-keys.json
+
+# Download root-token with SSE-C
+aws s3api get-object \
+  --bucket <BUCKET_NAME> \
+  --key <BUCKET_PATH>/vault/root-token \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key <BASE64_ENCODED_ENCRYPTION_KEY> \
+  root-token
+```
+
+### 3. Re-upload Objects Using SSE-KMS
+
+```bash
+# Upload unseal-keys.json with SSE-KMS
+aws s3api put-object \
+  --bucket <BUCKET_NAME> \
+  --key <BUCKET_PATH>/vault/unseal-keys.json \
+  --body unseal-keys.json \
+  --server-side-encryption aws:kms \
+  --ssekms-key-id <KMS_KEY_ARN>
+
+# Upload root-token with SSE-KMS
+aws s3api put-object \
+  --bucket <BUCKET_NAME> \
+  --key <BUCKET_PATH>/vault/root-token \
+  --body root-token \
+  --server-side-encryption aws:kms \
+  --ssekms-key-id <KMS_KEY_ARN>
+```
+
+### 4. Update vault-init Deployment Configuration
+
+Replace the environment variable in the pod spec / Helm values:
+
+**Before:**
+```yaml
+env:
+  - name: CLOUD_PROVIDER
+    value: "aws-s3"
+  - name: AWS_ENCRYPTION_KEY
+    value: "<plaintext-aes-key>"  # INSECURE
+  - name: AWS_BUCKET_NAME
+    value: "<bucket>"
+  - name: AWS_BUCKET_PATH
+    value: "<path>"
+```
+
+**After:**
+```yaml
+env:
+  - name: CLOUD_PROVIDER
+    value: "aws-s3"
+  - name: AWS_KMS_KEY_ID
+    value: "arn:aws:kms:<region>:<account>:key/<key-id>"
+  - name: AWS_BUCKET_NAME
+    value: "<bucket>"
+  - name: AWS_BUCKET_PATH
+    value: "<path>"
+```
+
+### 5. Deploy Updated vault-init
+
+Roll out the updated vault-init image with the new configuration. Verify the pod starts successfully and can read the re-encrypted objects.
+
+### 6. Verify Unseal Works
+
+```bash
+# Check vault-init logs for successful unseal
+kubectl logs <vault-init-pod> | grep -i "unseal"
+```
+
+### 7. Clean Up
+
+- Remove `AWS_ENCRYPTION_KEY` from all deployment manifests, Helm values, and secret stores
+- Rotate or revoke the old SSE-C key material
+- Consider adding a bucket policy that denies PutObject without SSE-KMS to prevent accidental plaintext or SSE-C uploads:
+
+```json
+{
+  "Effect": "Deny",
+  "Principal": "*",
+  "Action": "s3:PutObject",
+  "Resource": "arn:aws:s3:::<BUCKET_NAME>/<BUCKET_PATH>/vault/*",
+  "Condition": {
+    "StringNotEquals": {
+      "s3:x-amz-server-side-encryption": "aws:kms"
+    }
+  }
+}
+```
+
+## Rollback
+
+If issues arise, the rollback path is:
+1. Re-download objects using SSE-KMS (`aws s3api get-object` without SSE-C flags)
+2. Re-upload with the old SSE-C key
+3. Revert the vault-init deployment to the previous image/config
+
+## Security Notes
+
+- The old `AWS_ENCRYPTION_KEY` should be treated as compromised if it was ever visible in pod specs, logs, or monitoring systems. Even after migration, rotate any secrets that were protected solely by that key.
+- With SSE-KMS, access control is enforced by both the S3 bucket policy AND the KMS key policy. An attacker needs both `s3:GetObject` and `kms:Decrypt` to read the vault secrets.
+- The KMS key policy should restrict `kms:Decrypt` to only the vault-init IAM role and break-glass admin roles.

--- a/main.go
+++ b/main.go
@@ -74,10 +74,10 @@ func createAwsKeystore() *keystore.AwsKeystore {
 
 func createAwsS3Keystore() *keystore.AwsS3Keystore {
 	s3Keystore, err := keystore.NewAwsS3Keystore(&keystore.AwsS3KeystoreConfig{
-		AwsConfig:     createAwsConfig(),
-		EncryptionKey: getEnv("AWS_ENCRYPTION_KEY"),
-		BucketName:    getEnv("AWS_BUCKET_NAME"),
-		BucketPath:    getEnv("AWS_BUCKET_PATH"),
+		AwsConfig:  createAwsConfig(),
+		KmsKeyID:   getEnv("AWS_KMS_KEY_ID"),
+		BucketName: getEnv("AWS_BUCKET_NAME"),
+		BucketPath: getEnv("AWS_BUCKET_PATH"),
 	})
 	if err != nil {
 		log.Fatalf("failed to initialize aws store: %v", err)

--- a/pkg/keystore/awsS3Keystore.go
+++ b/pkg/keystore/awsS3Keystore.go
@@ -3,8 +3,6 @@ package keystore
 import (
 	"bytes"
 	"context"
-	"crypto/md5"
-	"encoding/base64"
 	"encoding/json"
 	"io"
 	"path"
@@ -16,18 +14,17 @@ import (
 )
 
 type AwsS3Keystore struct {
-	encryptionKey    string
-	encryptionKeyMD5 string
-	bucketName       string
-	bucketPath       string
-	s3Service        *s3.S3
+	kmsKeyID   string
+	bucketName string
+	bucketPath string
+	s3Service  *s3.S3
 }
 
 type AwsS3KeystoreConfig struct {
-	AwsConfig     *AwsConfig
-	EncryptionKey string
-	BucketName    string
-	BucketPath    string
+	AwsConfig  *AwsConfig
+	KmsKeyID   string
+	BucketName string
+	BucketPath string
 }
 
 func NewAwsS3Keystore(config *AwsS3KeystoreConfig) (*AwsS3Keystore, error) {
@@ -35,18 +32,14 @@ func NewAwsS3Keystore(config *AwsS3KeystoreConfig) (*AwsS3Keystore, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	s3Service := s3.New(awsSession)
 
-	md5Sum := md5.Sum([]byte(config.EncryptionKey))
-	encryptionKeyMD5 := base64.StdEncoding.EncodeToString(md5Sum[:])
-
 	return &AwsS3Keystore{
-		encryptionKey:    config.EncryptionKey,
-		encryptionKeyMD5: encryptionKeyMD5,
-		bucketName:       config.BucketName,
-		bucketPath:       config.BucketPath,
-		s3Service:        s3Service,
+		kmsKeyID:   config.KmsKeyID,
+		bucketName: config.BucketName,
+		bucketPath: config.BucketPath,
+		s3Service:  s3Service,
 	}, nil
 }
 
@@ -84,11 +77,8 @@ func (keystore *AwsS3Keystore) EncryptAndWrite(initResponse *api.InitResponse) e
 
 func (keystore *AwsS3Keystore) ReadAndDecrypt() (*api.InitResponse, error) {
 	getObjectInput := s3.GetObjectInput{
-		Bucket:               &keystore.bucketName,
-		Key:                  aws.String(keystore.getBucketPath(unsealKeysFile)),
-		SSECustomerKey:       &keystore.encryptionKey,
-		SSECustomerKeyMD5:    &keystore.encryptionKeyMD5,
-		SSECustomerAlgorithm: aws.String(s3.ServerSideEncryptionAes256),
+		Bucket: &keystore.bucketName,
+		Key:    aws.String(keystore.getBucketPath(unsealKeysFile)),
 	}
 	getObjectOutput, err := keystore.s3Service.GetObjectWithContext(context.Background(), &getObjectInput)
 	if err != nil {
@@ -109,9 +99,8 @@ func (keystore *AwsS3Keystore) s3Put(name string, body io.ReadSeeker) error {
 		Bucket:               &keystore.bucketName,
 		Key:                  &name,
 		Body:                 body,
-		SSECustomerKey:       &keystore.encryptionKey,
-		SSECustomerKeyMD5:    &keystore.encryptionKeyMD5,
-		SSECustomerAlgorithm: aws.String(s3.ServerSideEncryptionAes256),
+		ServerSideEncryption: aws.String("aws:kms"),
+		SSEKMSKeyId:          &keystore.kmsKeyID,
 	}
 
 	_, err := keystore.s3Service.PutObjectWithContext(context.Background(), &putObjectInput)


### PR DESCRIPTION
## Summary

- Replaces SSE-C (customer-provided key via `AWS_ENCRYPTION_KEY` env var) with SSE-KMS (`AWS_KMS_KEY_ID`) for S3 backend encryption
- The data encryption key never leaves AWS KMS, eliminating exposure in pod specs, process env, and observability tooling
- Includes migration documentation for existing deployments

## Breaking Change

This is a **breaking change** for existing deployments using the S3 backend:
- Existing objects encrypted with SSE-C cannot be read by the new code
- Requires a manual data migration (see `docs/migrate-s3-sse-c-to-sse-kms.md`)
- IAM role must be updated with `kms:Encrypt`, `kms:Decrypt`, `kms:GenerateDataKey` permissions
- Environment variable changes: `AWS_ENCRYPTION_KEY` → `AWS_KMS_KEY_ID`

## Test plan

- [ ] Verify new deployment with SSE-KMS works end-to-end (init + unseal)
- [ ] Validate migration procedure from SSE-C to SSE-KMS on a test cluster
- [ ] Confirm IAM policy requirements documented correctly
- [ ] Coordinate deployment with infrastructure team (IAM + KMS key provisioning)

GENAI=YES

🤖 Generated with [Claude Code](https://claude.com/claude-code)